### PR TITLE
improvement: Add better error reporting for when the tool fails to load the config file (CY-5214)

### DIFF
--- a/src/engineImpl.ts
+++ b/src/engineImpl.ts
@@ -51,7 +51,7 @@ export const engineImpl: Engine = async function (
 
                     return (e instanceof Error)
                         ? e.message
-                        : "unknown error"
+                        : String(e)
                 })
 
             if (maybeSpectral && typeof maybeSpectral != "string") {

--- a/src/engineImpl.ts
+++ b/src/engineImpl.ts
@@ -48,16 +48,22 @@ export const engineImpl: Engine = async function (
             const maybeSpectral = await createSpectralWithConfFile(existsConfFile)
                 .catch(e => {
                     debug(`some error occurred loading conf file: ${e}`)
-                    return undefined
+
+                    return (e instanceof Error)
+                        ? e.message
+                        : "unknown error"
                 })
 
-            if (maybeSpectral)  {
+            if (maybeSpectral && typeof maybeSpectral != "string") {
                 spectral = maybeSpectral
             } else {
                 debug("couldn't create spectral with configuration...")
 
+                const someError = maybeSpectral
                 throw new Error(
-                    "A configuration file was found but an error occurred trying to load it."
+                    someError
+                        ? `A configuration file was found but an error occurred trying to load it:\n${someError}`
+                        : "A configuration file was found but an error occurred trying to load it."
                 )
             }
         } else {


### PR DESCRIPTION
I noticed that on the UI when it fails to load the configuration file there was no useful feedback for the user to understand from the logs shown when the tool fails if it's something they can do about it.

This way it properly exposes the internal error messages from spectral when failing to load the config file which helps the user in diagnosing the issue in that case.

Example output before and after on the cli:

```
Error: A configuration file was found but an error occurred trying to load it.
    at engineImpl (/dist/src/engineImpl.js:67:23)
```

```
Error: A configuration file was found but an error occurred trying to load it:
Error at #/rules/adidas-oas3-valid-example-in-parameters: must be equal to one of the allowed values
Error at #/rules/adidas-oas3-valid-example-in-definitions: must be equal to one of the allowed values
Error at #/rules/adidas-oas3-valid-example-in-parameters/then: must have required property 'function'
Error at #/rules/adidas-oas3-valid-example-in-definitions/then: must have required property 'function'
    at engineImpl (/dist/src/engineImpl.js:70:23)
```